### PR TITLE
refactor: Test remove jinja2 from var_network_filtering_service.var

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2442,7 +2442,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    rules:  
+    rules:
       - file_groupownerships_var_log_apt
       - file_groupownerships_var_log_gdm
       - file_groupownerships_var_log_gdm3

--- a/linux_os/guide/system/network/var_network_filtering_service.var
+++ b/linux_os/guide/system/network/var_network_filtering_service.var
@@ -11,17 +11,10 @@ operator: equals
 
 interactive: true
 
-{{% if 'ubuntu' in product %}}
-options:
-    iptables: iptables
-    nftables: nftables
-    ufw: ufw
-    default: nftables
-{{% else %}}
 options:
     iptables: iptables
     nftables: nftables
     firewalld: firewalld
     ufw: ufw
+    # ubuntu product default use nftables
     default: firewalld
-{{% endif %}}


### PR DESCRIPTION
#### Description:

Test remove jinja2 from var_network_filtering_service.var

#### Rationale:

Do it for trestle-bot 

#### Review Hints:

Check all reference of var_network_filtering_service.var 
